### PR TITLE
Add config module and add it to existing methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 *.eggs
 *.pytest_cache/
 .cache/
+build/
+dist/
+*.egg-info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include config.ini

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,17 @@
+[mainnet]
+epoch = 2017-03-21 13:00:00
+version = 23
+nethash = 6e84d08bd299ed97c212c886c98a57e36545c8f5d645ca7eeae63a8bd62d8988
+wif = 170
+
+[devnet]
+epoch = 2017-03-21 13:00:00
+version = 30
+nethash = 578e820911f24e039733b45e4882b73e301f813a0d2c31330dafda84534ffa23
+wif = 170
+
+[testnet]
+epoch = 2017-03-21 13:00:00
+version = 23
+nethash = d9acd04bde4234a81addb8482333b4ac906bed7be5a9970ce8ada428bd083192
+wif = 186

--- a/crypto/conf.py
+++ b/crypto/conf.py
@@ -1,0 +1,56 @@
+import os
+from configparser import ConfigParser
+from datetime import datetime
+
+from crypto.exceptions import ArkNetworkSettingsException
+
+config_file = os.path.abspath('config.ini')
+
+settings = ConfigParser()
+settings.read(config_file)
+
+network = {}
+
+
+def use_network(network_name):
+    """Select what network you want to use in the crypto library
+
+    Args:
+        network_name (str): name of a network, default ones are ARK's mainnet, devnet & testnet
+    """
+    global network
+    network = {
+        'epoch': datetime.strptime(settings.get(network_name, 'epoch'), '%Y-%m-%d %H:%M:%S'),
+        'version': int(settings.get(network_name, 'version')),
+        'nethash': settings.get(network_name, 'nethash'),
+        'wif': int(settings.get(network_name, 'wif')),
+    }
+
+
+def get_network():
+    """Get settings for a selected network
+
+    Returns:
+        dict: network settings
+    """
+    if not network:
+        raise ArkNetworkSettingsException('Network has not been set')
+    return network
+
+
+def set_custom_network(epoch, version, nethash, wif):
+    """Set custom network
+
+    Args:
+        epoch (datetime): chains epoch time
+        version (int): chains version
+        nethash (str): chains nethash
+        wif (int): chains wif
+    """
+    section_name = 'custom'
+    if section_name not in settings.sections():
+        settings.add_section(section_name)
+    settings.set(section_name, 'epoch', epoch.strftime('%Y-%m-%d %H:%M:%S'))
+    settings.set(section_name, 'version', str(version))
+    settings.set(section_name, 'nethash', nethash)
+    settings.set(section_name, 'wif', str(wif))

--- a/crypto/exceptions.py
+++ b/crypto/exceptions.py
@@ -12,3 +12,7 @@ class ArkBadSignatureException(ArkCryptoException):
 
 class ArkBadDigestException(ArkCryptoException):
     """Raised when a curve is too short for a digest"""
+
+
+class ArkNetworkSettingsException(ArkCryptoException):
+    """Raised when a curve is too short for a digest"""

--- a/crypto/serializer.py
+++ b/crypto/serializer.py
@@ -5,6 +5,7 @@ from importlib import import_module
 from binary.hex.writer import write_high, write_low
 from binary.unsigned_integer.writer import write_bit32, write_bit64, write_bit8
 
+from crypto.conf import get_network
 from crypto.constants import TRANSACTION_TYPES
 from crypto.exceptions import ArkSerializerException
 from crypto.serializers.base import BaseSerializer
@@ -25,10 +26,11 @@ class Serializer(object):
         Returns:
             bytes: bytes string
         """
+        network_config = get_network()
         bytes_data = bytes()
         bytes_data += write_bit8(0xff)
         bytes_data += write_low(self.transaction.get('version') or 0x01)
-        bytes_data += write_bit8(self.transaction.get('network') or 1337)  # todo:
+        bytes_data += write_bit8(self.transaction.get('network') or network_config['version'])
         bytes_data += write_low(self.transaction['type'])
         bytes_data += write_bit32(self.transaction['timestamp'])
         bytes_data += write_high(self.transaction['senderPublicKey'])

--- a/crypto/slot.py
+++ b/crypto/slot.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+from crypto.conf import get_network
+
+
+def get_time():
+    """Get the time difference between now and network start.
+
+    Returns:
+        int: difference in seconds
+    """
+    now = datetime.utcnow()
+    network = get_network()
+    diff = (now - network['epoch']).seconds
+    return diff

--- a/crypto/transactions/base.py
+++ b/crypto/transactions/base.py
@@ -9,6 +9,7 @@ from binary.unsigned_integer.writer import write_bit32, write_bit64
 
 from crypto.identity.keys import public_key_from_secret
 from crypto.message import sign_message, verify_message
+from crypto.slot import get_time
 
 
 class BaseTransaction(object):
@@ -19,7 +20,7 @@ class BaseTransaction(object):
         self.type = self.get_type()
         self.fee = None
         self.vendor_field = None
-        self.timestamp = 1490101200  # todo Slot::getTime()
+        self.timestamp = get_time()
         self.sender_public_key = None
         self.signature = None
         self.sign_signature = None

--- a/tests/serializers/test_delegate_registration.py
+++ b/tests/serializers/test_delegate_registration.py
@@ -1,6 +1,8 @@
+from crypto.conf import use_network
 from crypto.serializer import Serializer
 
 
 def test_serializer(transaction_type_2):
+    use_network('devnet')
     result = Serializer(transaction_type_2).serialize()
     assert result == transaction_type_2['serialized']

--- a/tests/serializers/test_delegate_resignation.py
+++ b/tests/serializers/test_delegate_resignation.py
@@ -1,10 +1,11 @@
 import pytest
 
+from crypto.conf import use_network
 from crypto.serializer import Serializer
 
 
-@pytest.mark.skip(reason='not implemented')
+@pytest.mark.skip(reason='not implemented - missing fixture')
 def test_serializer(transaction_type_8):
-    # todo: must implement fallback method for fetching network version in serializer.py
+    use_network('devnet')
     result = Serializer(transaction_type_8).serialize()
     assert result == transaction_type_8['serialized']

--- a/tests/serializers/test_ipfs.py
+++ b/tests/serializers/test_ipfs.py
@@ -1,10 +1,11 @@
 import pytest
 
+from crypto.conf import use_network
 from crypto.serializer import Serializer
 
 
-@pytest.mark.skip(reason='not implemented')
+@pytest.mark.skip(reason='not implemented - missing fixture')
 def test_serializer(transaction_type_5):
-    # todo: must implement fallback method for fetching network version in serializer.py
+    use_network('devnet')
     result = Serializer(transaction_type_5).serialize()
     assert result == transaction_type_5['serialized']

--- a/tests/serializers/test_multi_payment.py
+++ b/tests/serializers/test_multi_payment.py
@@ -1,10 +1,11 @@
 import pytest
 
+from crypto.conf import use_network
 from crypto.serializer import Serializer
 
 
-@pytest.mark.skip(reason='not implemented')
+@pytest.mark.skip(reason='not implemented - missing fixture')
 def test_serializer(transaction_type_7):
-    # todo: must implement fallback method for fetching network version in serializer.py
+    use_network('devnet')
     result = Serializer(transaction_type_7).serialize()
     assert result == transaction_type_7['serialized']

--- a/tests/serializers/test_multi_signature_registration.py
+++ b/tests/serializers/test_multi_signature_registration.py
@@ -1,6 +1,8 @@
+from crypto.conf import use_network
 from crypto.serializer import Serializer
 
 
 def test_serializer(transaction_type_4):
+    use_network('devnet')
     result = Serializer(transaction_type_4).serialize()
     assert result == transaction_type_4['serialized']

--- a/tests/serializers/test_second_signature_registration.py
+++ b/tests/serializers/test_second_signature_registration.py
@@ -1,6 +1,8 @@
+from crypto.conf import use_network
 from crypto.serializer import Serializer
 
 
 def test_serializer(transaction_type_1):
+    use_network('devnet')
     result = Serializer(transaction_type_1).serialize()
     assert result == transaction_type_1['serialized']

--- a/tests/serializers/test_timelock_transfer.py
+++ b/tests/serializers/test_timelock_transfer.py
@@ -1,10 +1,11 @@
 import pytest
 
+from crypto.conf import use_network
 from crypto.serializer import Serializer
 
 
-@pytest.mark.skip(reason='not implemented')
+@pytest.mark.skip(reason='not implemented - missing fixture')
 def test_serializer(transaction_type_6):
-    # todo: must implement fallback method for fetching network version in serializer.py
+    use_network('devnet')
     result = Serializer(transaction_type_6).serialize()
     assert result == transaction_type_6['serialized']

--- a/tests/serializers/test_vote.py
+++ b/tests/serializers/test_vote.py
@@ -1,6 +1,8 @@
+from crypto.conf import use_network
 from crypto.serializer import Serializer
 
 
 def test_serializer(transaction_type_3):
+    use_network('devnet')
     result = Serializer(transaction_type_3).serialize()
     assert result == transaction_type_3['serialized']

--- a/tests/transactions/test_delegate_registration.py
+++ b/tests/transactions/test_delegate_registration.py
@@ -1,3 +1,4 @@
+from crypto.conf import use_network
 from crypto.constants import TRANSACTION_DELEGATE_REGISTRATION
 from crypto.transactions.delegate_registration import DelegateRegistrationTransaction
 
@@ -5,6 +6,7 @@ from crypto.transactions.delegate_registration import DelegateRegistrationTransa
 def test_delegate_registration_transaction():
     """Test if a delegate registration transaction gets built
     """
+    use_network('devnet')
     delegate_name = 'mr.delegate'.encode()
     transaction = DelegateRegistrationTransaction(delegate_name)
     transaction.sign('testing'.encode())

--- a/tests/transactions/test_multi_signature_registration.py
+++ b/tests/transactions/test_multi_signature_registration.py
@@ -1,3 +1,4 @@
+from crypto.conf import use_network
 from crypto.constants import TRANSACTION_MULTI_SIGNATURE_REGISTRATION
 from crypto.transactions.multi_signature_registration import MultiSignatureRegistrationTransaction
 
@@ -5,6 +6,7 @@ from crypto.transactions.multi_signature_registration import MultiSignatureRegis
 def test_multi_signature_registration_transaction():
     """Test if a second signature registration transaction gets built
     """
+    use_network('devnet')
     keysgroup = [
         '03a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933',
         '13a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933',

--- a/tests/transactions/test_second_signature_registration.py
+++ b/tests/transactions/test_second_signature_registration.py
@@ -1,3 +1,4 @@
+from crypto.conf import use_network
 from crypto.constants import TRANSACTION_SECOND_SIGNATURE_REGISTRATION
 from crypto.transactions.second_signature_registration import SecondSignatureRegistrationTransaction
 
@@ -5,6 +6,7 @@ from crypto.transactions.second_signature_registration import SecondSignatureReg
 def test_second_signature_registration_transaction():
     """Test if a second signature registration transaction gets built
     """
+    use_network('devnet')
     transaction = SecondSignatureRegistrationTransaction('this is the second passphrase'.encode())
     transaction.sign('testing'.encode())
     transaction_dict = transaction.to_dict()

--- a/tests/transactions/test_transfer.py
+++ b/tests/transactions/test_transfer.py
@@ -1,3 +1,4 @@
+from crypto.conf import use_network
 from crypto.constants import TRANSACTION_TRANSFER
 from crypto.transactions.transfer import TransferTransaction
 
@@ -5,6 +6,7 @@ from crypto.transactions.transfer import TransferTransaction
 def test_transfer_transaction():
     """Test if a transfer transaction gets built
     """
+    use_network('devnet')
     transaction = TransferTransaction(
         recipient_id='AXoXnFi4z1Z6aFvjEYkDVCtBGW2PaRiM25',
         amount=133380000000,

--- a/tests/transactions/test_vote.py
+++ b/tests/transactions/test_vote.py
@@ -1,3 +1,4 @@
+from crypto.conf import use_network
 from crypto.constants import TRANSACTION_VOTE
 from crypto.transactions.vote import VoteTransaction
 
@@ -5,6 +6,7 @@ from crypto.transactions.vote import VoteTransaction
 def test_vote_transaction():
     """Test if a vote transaction gets built
     """
+    use_network('devnet')
     vote = '+034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'
     transaction = VoteTransaction(vote)
     transaction.sign('testing'.encode())


### PR DESCRIPTION
## Changes
- Added conf module and included it where it was missing + modified tests
- including config.ini in the build via `MANIFEST.in` - [more info](https://docs.python.org/3/distutils/sourcedist.html#specifying-the-files-to-distribute)

### Usage
By default, if you just want to create a transaction without specifying a network an exception will be raised. This means that when you import the library you have to select what network you want to use. Available networks are specified in the `config.ini` file.

In case you want to use your own **custom network**, you can set it by using the `set_custom_network()`. When you set a custom network it will be assigned to a "custom" network key, so you'll have the following networks available in the config: **mainnet**, **devnet**, **testnet** and **custom**. After you set the network, it is added to the conf and you have to use it (otherwise the exception will be raised) by doing `use_network('custom')` so that it's set in the config file.

### Examples
#### Using a devnet network
```py
from crypto.conf import use_network, get_network

use_network('devnet')  # select a network you want to use
network = get_network()  # get the network that you've just selected
```

#### Set a custom network
```py
from datetime import datetime
from crypto.conf import set_custom_network, use_network, get_network

set_custom_network(
    epoch=datetime.now(),
    version=99,
    nethash='578e820911f24e039733b45e4882b73e301f813a0d2c31330dafda84534ffa23',
    wip=199
)
use_network('custom')   # select a network you want to use
network = get_network()  # get the network that you've just selected
```