### PR TITLE
Refactor message module to better reflect other crypto libraries

### DIFF
--- a/crypto/exceptions.py
+++ b/crypto/exceptions.py
@@ -6,13 +6,9 @@ class ArkSerializerException(ArkCryptoException):
     """Raised when there's a serializer related issue"""
 
 
-class ArkBadSignatureException(ArkCryptoException):
-    """Raised when a signature is not valid"""
-
-
-class ArkBadDigestException(ArkCryptoException):
-    """Raised when a curve is too short for a digest"""
-
-
 class ArkNetworkSettingsException(ArkCryptoException):
     """Raised when a curve is too short for a digest"""
+
+
+class ArkInvalidTransaction(ArkCryptoException):
+    """Raised when transaction is not valid"""

--- a/crypto/identity/private_key.py
+++ b/crypto/identity/private_key.py
@@ -19,7 +19,7 @@ class PrivateKey(object):
         Returns:
             str: signature of the signed message
         """
-        signature = self.pvt_key_object.sign(message)
+        signature = self.private_key.sign(message)
         return hexlify(signature).decode()
 
     def to_hex(self):

--- a/crypto/transactions/builder/base.py
+++ b/crypto/transactions/builder/base.py
@@ -1,7 +1,7 @@
 from hashlib import sha256
 
 from crypto.identity.public_key import PublicKey
-from crypto.message import sign_message
+from crypto.message import Message
 from crypto.resources.transaction import Transaction
 
 
@@ -24,8 +24,8 @@ class BaseTransactionBuilder(object):
             passphrase (str): passphrase associated with the account sending this transaction
         """
         self.transaction.senderPublicKey = PublicKey.from_passphrase(passphrase)
-        message = sign_message(self.transaction.to_bytes(), passphrase)
-        self.transaction.signature = message['signature']
+        message = Message.sign(self.transaction.to_bytes(), passphrase)
+        self.transaction.signature = message.signature
         self.transaction.id = self.transaction.get_id()
 
     def second_sign(self, passphrase):
@@ -35,8 +35,8 @@ class BaseTransactionBuilder(object):
             passphrase (str): 2nd passphrase associated with the account sending this transaction
         """
         transaction = sha256(self.transaction.to_bytes()).digest()
-        message = sign_message(transaction, passphrase)
-        self.transaction.signSignature = message['signature']
+        message = Message.sign(transaction, passphrase)
+        self.transaction.signSignature = message.signature
         self.transaction.id = self.transaction.get_id()
 
     def verify(self):

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,7 @@ import setuptools
 requires = [
     'base58',
     'binary-helpers',
-    'coincurve',
-    'bit'
+    'coincurve'
 ]
 
 tests_require = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,7 +180,7 @@ def transaction_type_8():
 def message():
     data = {
         'data': {
-            'publickey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
+            'public_key': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
             'signature': '304402200fb4adddd1f1d652b544ea6ab62828a0a65b712ed447e2538db0caebfa68929e02205ecb2e1c63b29879c2ecf1255db506d671c8b3fa6017f67cfd1bf07e6edd1cc8',  # noqa
             'message': 'Hello World'
         },

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,8 +1,25 @@
-from crypto.message import sign_message, verify_message
+import json
+from collections import OrderedDict
+
+from crypto.message import Message
 
 
-def test_signing_and_verifying_a_message(message):
-    data = sign_message(message['data']['message'].encode(), message['passphrase'])
-    signature = data['signature']
-    public_key = data['public_key']
-    assert verify_message(message['data']['message'], public_key, signature) is True
+def test_signing(message):
+    result = Message.sign(message['data']['message'], message['passphrase'])
+    assert OrderedDict(result.to_dict()) == OrderedDict(message['data'])
+
+
+def test_verify(message):
+    result = Message(**message['data'])
+    assert result.verify() is True
+
+
+def test_to_dict(message):
+    result = Message(**message['data'])
+    assert OrderedDict(result.to_dict()) == OrderedDict(message['data'])
+
+
+def test_to_json(message):
+    result = Message(**message['data'])
+    json_data = result.to_json()
+    assert OrderedDict(json.loads(json_data)) == OrderedDict(message['data'])

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,12 +1,11 @@
 import json
-from collections import OrderedDict
 
 from crypto.message import Message
 
 
 def test_signing(message):
     result = Message.sign(message['data']['message'], message['passphrase'])
-    assert OrderedDict(result.to_dict()) == OrderedDict(message['data'])
+    assert result.to_dict() == message['data']
 
 
 def test_verify(message):
@@ -16,10 +15,13 @@ def test_verify(message):
 
 def test_to_dict(message):
     result = Message(**message['data'])
-    assert OrderedDict(result.to_dict()) == OrderedDict(message['data'])
+    assert result.to_dict() == message['data']
 
 
 def test_to_json(message):
     result = Message(**message['data'])
     json_data = result.to_json()
-    assert OrderedDict(json.loads(json_data)) == OrderedDict(message['data'])
+    data = json.loads(json_data)
+    assert data['signature'] == message['data']['signature']
+    assert data['public_key'] == message['data']['public_key']
+    assert data['message'] == message['data']['message']


### PR DESCRIPTION
## Proposed changes

The following change resolves #30 and #35, where `verify()` method in the message raises an exception again and refactors the message module to reflect other crypto libraries.

After completing these changes I've run the TransferBuilder and successfully [made a transaction](https://dexplorer.ark.io/transaction/43b5cf6f5aebd2151e72fd3ba41ccf21c58ac836180c71a4172896192b45d416) - this is just to prove that nothing regarding signing didn't break.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Test (adding missing tests or fixing existing tests)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/docs/contributing) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)