### PR TITLE
misc: remove "contributions closed" from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-‼️ **Contributions are closed**
-
 ## Proposed changes
 
 Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.


### PR DESCRIPTION
## Proposed changes

Remove "Contributions are closed" message from PR template.

## Types of changes

- [x] Other... Please describe: changed PR template

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes

## Further comments

None
