### PR TITLE
fix: skip recipient_id in to_bytes for tx type 1 and 4

### DIFF
--- a/crypto/transactions/transaction.py
+++ b/crypto/transactions/transaction.py
@@ -91,7 +91,8 @@ class Transaction(object):
         bytes_data += write_bit32(self.timestamp)
         bytes_data += write_high(self.senderPublicKey)
 
-        if self.recipientId:
+        skip_recipient_id = self.type == TRANSACTION_SECOND_SIGNATURE_REGISTRATION or self.type == TRANSACTION_MULTI_SIGNATURE_REGISTRATION
+        if self.recipientId and not skip_recipient_id:
             bytes_data += b58decode_check(self.recipientId)
         else:
             bytes_data += pack('21x')

--- a/tests/transactions/deserializers/test_delegate_registration.py
+++ b/tests/transactions/deserializers/test_delegate_registration.py
@@ -6,3 +6,4 @@ def test_delegate_registration_deserializer():
     deserializer = Deserializer(serialized)
     actual = deserializer.deserialize()
     assert actual.asset['delegate'] == {'username': 'boldninja'}
+    actual.verify()

--- a/tests/transactions/deserializers/test_multi_signature_registration.py
+++ b/tests/transactions/deserializers/test_multi_signature_registration.py
@@ -13,3 +13,4 @@ def test_multi_signature_registration_deserializer():
         '+0276dc5b8706a85ca9fdc46e571ac84e52fbb48e13ec7a165a80731b44ae89f1fc',
         '+02e8d5d17eb17bbc8d7bf1001d29a2d25d1249b7bb7a5b7ad8b7422063091f4b31'
     ]
+    actual.verify()

--- a/tests/transactions/deserializers/test_second_signature_registration.py
+++ b/tests/transactions/deserializers/test_second_signature_registration.py
@@ -6,3 +6,4 @@ def test_second_signature_registration():
     deserializer = Deserializer(serialized)
     actual = deserializer.deserialize()
     assert actual.asset['signature']['publicKey'] == '03699e966b2525f9088a6941d8d94f7869964a000efe65783d78ac82e1199fe609'  # noqa
+    actual.verify()

--- a/tests/transactions/deserializers/test_transfer.py
+++ b/tests/transactions/deserializers/test_transfer.py
@@ -13,3 +13,4 @@ def test_transfer_deserializer():
     assert actual.recipientId == 'D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib'
     assert actual.senderPublicKey == '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'  # noqa
     assert actual.id == 'da61c6cba363cc39baa0ca3f9ba2c5db81b9805045bd0b9fc58af07ad4206856'
+    actual.verify()

--- a/tests/transactions/deserializers/test_vote.py
+++ b/tests/transactions/deserializers/test_vote.py
@@ -6,3 +6,4 @@ def test_vote_deserializer():
     deserializer = Deserializer(serialized)
     actual = deserializer.deserialize()
     assert actual.asset['votes'] == ['+022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d']  # noqa
+    actual.verify()


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
In second signature and multi signature transactions the recipient id is not supposed to be included in the signature/id calculation. Add an additional check to `to_bytes` to explicitely exclude the recipientId. This also allows such transactions to be verified, even if the recipientId is set.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
<!--