### PR TITLE
fix: messages now can work with both publickey and publicKey

### DIFF
--- a/crypto/transactions/transaction.py
+++ b/crypto/transactions/transaction.py
@@ -181,7 +181,7 @@ class Transaction(object):
         will happen.
         """
         transaction = self.to_bytes()
-        message = Message(transaction, self.signature, self.senderPublicKey)
+        message = Message(message=transaction, signature=self.signature, publickey=self.senderPublicKey)
         is_valid = message.verify()
         if not is_valid:
             raise ArkInvalidTransaction('Transaction could not be verified')

--- a/crypto/utils/message.py
+++ b/crypto/utils/message.py
@@ -28,7 +28,7 @@ class Message(object):
         passphrase = passphrase.decode() if isinstance(passphrase, bytes) else passphrase
         private_key = PrivateKey.from_passphrase(passphrase)
         signature = private_key.sign(message_bytes)
-        return cls(message=message, signature=signature, publickey=private_key.public_key)
+        return cls(message=message, signature=signature, publicKey=private_key.public_key)
 
     def verify(self):
         """Verify the Message object
@@ -49,7 +49,7 @@ class Message(object):
             dict: dictionary consiting of public_key, signature and message
         """
         data = {
-            ('publickey' if hasattr(self, 'publickey') else 'publicKey'): (self.publickey if hasattr(self, 'publickey') else self.publicKey),
+            ('publicKey' if hasattr(self, 'publicKey') else 'publickey'): (self.publicKey if hasattr(self, 'publicKey') else self.publickey),
             'signature': self.signature,
             'message': self.message,
         }

--- a/crypto/utils/message.py
+++ b/crypto/utils/message.py
@@ -6,11 +6,12 @@ from crypto.identity.public_key import PublicKey
 
 
 class Message(object):
-
-    def __init__(self, message, signature, public_key):
-        self.public_key = public_key
-        self.signature = signature
-        self.message = message
+    def __init__(self, **kwargs):
+        for k in kwargs.keys():
+            if k in ['message', 'signature', 'publickey', 'publicKey']:
+                self.__setattr__(k, kwargs[k])
+            else:
+                raise TypeError('Invalid keyword argument %s' % k)
 
     @classmethod
     def sign(cls, message, passphrase):
@@ -23,11 +24,11 @@ class Message(object):
         Returns:
             Message: returns a message object
         """
-        message_byes = message if isinstance(message, bytes) else message.encode()
+        message_bytes = message if isinstance(message, bytes) else message.encode()
         passphrase = passphrase.decode() if isinstance(passphrase, bytes) else passphrase
         private_key = PrivateKey.from_passphrase(passphrase)
-        signature = private_key.sign(message_byes)
-        return cls(message, signature, private_key.public_key)
+        signature = private_key.sign(message_bytes)
+        return cls(message=message, signature=signature, publickey=private_key.public_key)
 
     def verify(self):
         """Verify the Message object
@@ -36,7 +37,7 @@ class Message(object):
             bool: returns a boolean - true if verified, false if not
         """
         message = self.message if isinstance(self.message, bytes) else self.message.encode()
-        key = PublicKey.from_hex(self.public_key)
+        key = PublicKey.from_hex(self.publickey) if hasattr(self, 'publickey') else PublicKey.from_hex(self.publicKey)
         signature = unhexlify(self.signature)
         is_verified = key.public_key.verify(signature, message)
         return is_verified
@@ -48,7 +49,7 @@ class Message(object):
             dict: dictionary consiting of public_key, signature and message
         """
         data = {
-            'public_key': self.public_key,
+            ('publickey' if hasattr(self, 'publickey') else 'publicKey'): (self.publickey if hasattr(self, 'publickey') else self.publicKey),
             'signature': self.signature,
             'message': self.message,
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,7 +180,7 @@ def transaction_type_8():
 def message():
     data = {
         'data': {
-            'public_key': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
+            'publickey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
             'signature': '304402200fb4adddd1f1d652b544ea6ab62828a0a65b712ed447e2538db0caebfa68929e02205ecb2e1c63b29879c2ecf1255db506d671c8b3fa6017f67cfd1bf07e6edd1cc8',  # noqa
             'message': 'Hello World'
         },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,13 +179,13 @@ def transaction_type_8():
 @pytest.fixture
 def message():
     data = {
-        'data': {
+        'camelCase_pk': {
             'publicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
             'signature': '304402200fb4adddd1f1d652b544ea6ab62828a0a65b712ed447e2538db0caebfa68929e02205ecb2e1c63b29879c2ecf1255db506d671c8b3fa6017f67cfd1bf07e6edd1cc8',  # noqa
             'message': 'Hello World'
         },
 
-        'pk': {
+        'snake_case_pk': {
           'publickey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
           'signature': '304402200fb4adddd1f1d652b544ea6ab62828a0a65b712ed447e2538db0caebfa68929e02205ecb2e1c63b29879c2ecf1255db506d671c8b3fa6017f67cfd1bf07e6edd1cc8',  # noqa
           'message': 'Hello World'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,9 +180,15 @@ def transaction_type_8():
 def message():
     data = {
         'data': {
-            'publickey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
+            'publicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
             'signature': '304402200fb4adddd1f1d652b544ea6ab62828a0a65b712ed447e2538db0caebfa68929e02205ecb2e1c63b29879c2ecf1255db506d671c8b3fa6017f67cfd1bf07e6edd1cc8',  # noqa
             'message': 'Hello World'
+        },
+
+        'pk': {
+          'publickey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
+          'signature': '304402200fb4adddd1f1d652b544ea6ab62828a0a65b712ed447e2538db0caebfa68929e02205ecb2e1c63b29879c2ecf1255db506d671c8b3fa6017f67cfd1bf07e6edd1cc8',  # noqa
+          'message': 'Hello World'
         },
         'passphrase': 'this is a top secret passphrase'
     }

--- a/tests/utils/test_message.py
+++ b/tests/utils/test_message.py
@@ -4,38 +4,38 @@ from crypto.utils.message import Message
 
 
 def test_signing(message):
-    result = Message.sign(message['data']['message'], message['passphrase'])
-    assert result.to_dict() == message['data']
+    result = Message.sign(message['camelCase_pk']['message'], message['passphrase'])
+    assert result.to_dict() == message['camelCase_pk']
 
 
 def test_verify_with_publickey(message):
-    result = Message(**message['pk'])
+    result = Message(**message['snake_case_pk'])
     assert result.verify() is True
 
 
 def test_verify_with_publicKey(message):
-    result = Message(**message['data'])
+    result = Message(**message['camelCase_pk'])
     assert result.verify() is True
 
 
 def test_to_dict(message):
-    result = Message(**message['data'])
-    assert result.to_dict() == message['data']
+    result = Message(**message['camelCase_pk'])
+    assert result.to_dict() == message['camelCase_pk']
 
 
 def test_to_json_with_publicKey(message):
-    result = Message(**message['data'])
+    result = Message(**message['camelCase_pk'])
     json_data = result.to_json()
     data = json.loads(json_data)
-    assert data['signature'] == message['data']['signature']
-    assert data['publicKey'] == message['data']['publicKey']
-    assert data['message'] == message['data']['message']
+    assert data['signature'] == message['camelCase_pk']['signature']
+    assert data['publicKey'] == message['camelCase_pk']['publicKey']
+    assert data['message'] == message['camelCase_pk']['message']
 
 
 def test_to_json_with_publickey(message):
-    result = Message(**message['pk'])
+    result = Message(**message['snake_case_pk'])
     json_data = result.to_json()
     data = json.loads(json_data)
-    assert data['signature'] == message['pk']['signature']
-    assert data['publickey'] == message['pk']['publickey']
-    assert data['message'] == message['pk']['message']
+    assert data['signature'] == message['snake_case_pk']['signature']
+    assert data['publickey'] == message['snake_case_pk']['publickey']
+    assert data['message'] == message['snake_case_pk']['message']

--- a/tests/utils/test_message.py
+++ b/tests/utils/test_message.py
@@ -8,7 +8,12 @@ def test_signing(message):
     assert result.to_dict() == message['data']
 
 
-def test_verify(message):
+def test_verify_with_publickey(message):
+    result = Message(**message['pk'])
+    assert result.verify() is True
+
+
+def test_verify_with_publicKey(message):
     result = Message(**message['data'])
     assert result.verify() is True
 
@@ -18,10 +23,19 @@ def test_to_dict(message):
     assert result.to_dict() == message['data']
 
 
-def test_to_json(message):
+def test_to_json_with_publicKey(message):
     result = Message(**message['data'])
     json_data = result.to_json()
     data = json.loads(json_data)
     assert data['signature'] == message['data']['signature']
-    assert data['publickey'] == message['data']['publickey']
+    assert data['publicKey'] == message['data']['publicKey']
     assert data['message'] == message['data']['message']
+
+
+def test_to_json_with_publickey(message):
+    result = Message(**message['pk'])
+    json_data = result.to_json()
+    data = json.loads(json_data)
+    assert data['signature'] == message['pk']['signature']
+    assert data['publickey'] == message['pk']['publickey']
+    assert data['message'] == message['pk']['message']

--- a/tests/utils/test_message.py
+++ b/tests/utils/test_message.py
@@ -23,5 +23,5 @@ def test_to_json(message):
     json_data = result.to_json()
     data = json.loads(json_data)
     assert data['signature'] == message['data']['signature']
-    assert data['public_key'] == message['data']['public_key']
+    assert data['publickey'] == message['data']['publickey']
     assert data['message'] == message['data']['message']


### PR DESCRIPTION
## Proposed changes
Allow the use of both publickey and publicKey for the Message class to work correctly with the API.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works