### PR TITLE
fix: enable vendorfield for htlc lock

### DIFF
--- a/crypto/transactions/builder/htlc_lock.py
+++ b/crypto/transactions/builder/htlc_lock.py
@@ -6,7 +6,7 @@ class HtlcLock(BaseTransactionBuilder):
 
     transaction_type = TRANSACTION_HTLC_LOCK
 
-    def __init__(self, recipient_id, secret_hash, expiration_type, expiration_value, fee=None):
+    def __init__(self, recipient_id, secret_hash, expiration_type, expiration_value, vendorField=None, fee=None):
         """Create a timelock transaction
 
         Args:
@@ -14,6 +14,7 @@ class HtlcLock(BaseTransactionBuilder):
             secret_hash (str): a hash of the secret. The SAME hash must be used in the corresponding “claim” transaction
             expiration_type (int): type of the expiration. Either block height or network epoch timestamp based
             expiration_value (int): Expiration of transaction in seconds or height depending on expiration_type
+            vendorField (str): value for the vendor field aka smartbridge
             fee (int, optional): fee used for the transaction (default is already set)
         """
         super().__init__()
@@ -29,6 +30,8 @@ class HtlcLock(BaseTransactionBuilder):
                 'value': expiration_value
             }
         }
+
+        self.transaction.vendorField = vendorField.encode() if vendorField else None
 
         if fee:
             self.transaction.fee = fee


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds the vendorField argument to the HTLC Lock builder.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
