### PR TITLE
refactor: unit converter parse as int

### DIFF
--- a/crypto/transactions/builder/base.py
+++ b/crypto/transactions/builder/base.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 from crypto.configuration.network import get_network
 from crypto.identity.private_key import PrivateKey
@@ -25,7 +25,7 @@ class AbstractTransactionBuilder:
     def new(cls, data: Optional[dict] = None):
         return cls(data)
 
-    def gas_limit(self, gas_limit: int | str):
+    def gas_limit(self, gas_limit: Union[int, str]):
         self.transaction.data['gasLimit'] = gas_limit
         return self
 
@@ -33,7 +33,7 @@ class AbstractTransactionBuilder:
         self.transaction.data['recipientAddress'] = recipient_address
         return self
 
-    def gas_price(self, gas_price: int | str):
+    def gas_price(self, gas_price: Union[int, str]):
         self.transaction.data['gasPrice'] = gas_price
         return self
 

--- a/crypto/transactions/builder/base.py
+++ b/crypto/transactions/builder/base.py
@@ -1,5 +1,4 @@
-from typing import Optional, Union
-
+from typing import Optional
 from crypto.configuration.network import get_network
 from crypto.identity.private_key import PrivateKey
 from crypto.transactions.types.abstract_transaction import AbstractTransaction
@@ -8,7 +7,7 @@ from crypto.transactions.types.abstract_transaction import AbstractTransaction
 class AbstractTransactionBuilder:
     def __init__(self, data: Optional[dict] = None):
         default_data = {
-            'value': '0',
+            'value': 0,
             'senderPublicKey': '',
             'gasPrice': '5',
             'nonce': '1',
@@ -25,16 +24,16 @@ class AbstractTransactionBuilder:
     def new(cls, data: Optional[dict] = None):
         return cls(data)
 
-    def gas_limit(self, gas_limit: Union[int, str]):
-        self.transaction.data['gasLimit'] = gas_limit
+    def gas_limit(self, gas_limit: int):
+        self.transaction.data['gasLimit'] = int(gas_limit)
         return self
 
     def recipient_address(self, recipient_address: str):
         self.transaction.data['recipientAddress'] = recipient_address
         return self
 
-    def gas_price(self, gas_price: Union[int, str]):
-        self.transaction.data['gasPrice'] = gas_price
+    def gas_price(self, gas_price: int):
+        self.transaction.data['gasPrice'] = int(gas_price)
         return self
 
     def nonce(self, nonce: str):

--- a/crypto/transactions/builder/base.py
+++ b/crypto/transactions/builder/base.py
@@ -25,7 +25,7 @@ class AbstractTransactionBuilder:
     def new(cls, data: Optional[dict] = None):
         return cls(data)
 
-    def gas_limit(self, gas_limit: int):
+    def gas_limit(self, gas_limit: int | str):
         self.transaction.data['gasLimit'] = gas_limit
         return self
 
@@ -33,7 +33,7 @@ class AbstractTransactionBuilder:
         self.transaction.data['recipientAddress'] = recipient_address
         return self
 
-    def gas_price(self, gas_price: int):
+    def gas_price(self, gas_price: int | str):
         self.transaction.data['gasPrice'] = gas_price
         return self
 

--- a/crypto/transactions/builder/transfer_builder.py
+++ b/crypto/transactions/builder/transfer_builder.py
@@ -3,8 +3,8 @@ from crypto.transactions.types.transfer import Transfer
 
 
 class TransferBuilder(AbstractTransactionBuilder):
-    def value(self, value: str):
-        self.transaction.data['value'] = value
+    def value(self, value: int):
+        self.transaction.data['value'] = int(value)
         self.transaction.refresh_payload_data()
         return self
 

--- a/crypto/utils/unit_converter.py
+++ b/crypto/utils/unit_converter.py
@@ -8,18 +8,18 @@ class UnitConverter:
     ARK_MULTIPLIER = '1000000000000000000'  # 1e18
 
     @staticmethod
-    def parse_units(value: Union[float, int, str, Decimal], unit='ark') -> str:
+    def parse_units(value: Union[float, int, str, Decimal], unit='ark') -> int:
         value = Decimal(str(value))
 
         unit = unit.lower()
         if unit == 'wei':
-            return format((value * Decimal(UnitConverter.WEI_MULTIPLIER)).normalize(), 'f')
+            return int((value * Decimal(UnitConverter.WEI_MULTIPLIER)).normalize())
 
         if unit == 'gwei':
-            return format((value * Decimal(UnitConverter.GWEI_MULTIPLIER)).normalize(), 'f')
+            return int((value * Decimal(UnitConverter.GWEI_MULTIPLIER)).normalize())
 
         if unit == 'ark':
-            return format((value * Decimal(UnitConverter.ARK_MULTIPLIER)).normalize(), 'f')
+            return int((value * Decimal(UnitConverter.ARK_MULTIPLIER)).normalize())
 
         raise ValueError(f"Unsupported unit: {unit}. Supported units are 'wei', 'gwei', and 'ark'.")
 

--- a/tests/transactions/builder/conftest.py
+++ b/tests/transactions/builder/conftest.py
@@ -17,3 +17,9 @@ def username():
     """Username used for tests"""
 
     return 'fixture'
+
+@pytest.fixture
+def address():
+    """Address used for tests"""
+
+    return '0x6F0182a0cc707b055322CcF6d4CB6a5Aff1aEb22'

--- a/tests/transactions/builder/test_evm_call_builder.py
+++ b/tests/transactions/builder/test_evm_call_builder.py
@@ -19,7 +19,7 @@ def test_evm_call_transaction(passphrase, load_transaction_fixture):
     assert builder.transaction.data['network'] == fixture['data']['network']
     assert builder.transaction.data['gasLimit'] == fixture['data']['gasLimit']
     assert builder.transaction.data['recipientAddress'].lower() == fixture['data']['recipientAddress'].lower()
-    assert builder.transaction.data['value'] == fixture['data']['value']
+    assert builder.transaction.data['value'] == int(fixture['data']['value'])
     assert builder.transaction.data['v'] == fixture['data']['v']
     assert builder.transaction.data['r'] == fixture['data']['r']
     assert builder.transaction.data['s'] == fixture['data']['s']

--- a/tests/transactions/builder/test_transfer_builder.py
+++ b/tests/transactions/builder/test_transfer_builder.py
@@ -20,7 +20,7 @@ def test_it_should_sign_it_with_a_passphrase(passphrase, load_transaction_fixtur
     assert builder.transaction.data['network'] == fixture['data']['network']
     assert builder.transaction.data['gasLimit'] == fixture['data']['gasLimit']
     assert builder.transaction.data['recipientAddress'] == fixture['data']['recipientAddress']
-    assert builder.transaction.data['value'] == fixture['data']['value']
+    assert builder.transaction.data['value'] == int(fixture['data']['value'])
     assert builder.transaction.data['v'] == fixture['data']['v']
     assert builder.transaction.data['r'] == fixture['data']['r']
     assert builder.transaction.data['s'] == fixture['data']['s']
@@ -40,9 +40,9 @@ def test_it_should_handle_unit_converter(passphrase, address):
             .sign(passphrase)
     )
 
-    assert builder.transaction.data['gasPrice'] == '5000000000'
+    assert builder.transaction.data['gasPrice'] == 5000000000
     assert builder.transaction.data['nonce'] == '1'
-    assert builder.transaction.data['gasLimit'] == '100000000'
-    assert builder.transaction.data['value'] == '10000000000000000000'
+    assert builder.transaction.data['gasLimit'] == 100000000
+    assert builder.transaction.data['value'] == 10000000000000000000
 
     assert builder.verify()

--- a/tests/transactions/builder/test_transfer_builder.py
+++ b/tests/transactions/builder/test_transfer_builder.py
@@ -1,4 +1,5 @@
 from crypto.transactions.builder.transfer_builder import TransferBuilder
+from crypto.utils.unit_converter import UnitConverter
 
 def test_it_should_sign_it_with_a_passphrase(passphrase, load_transaction_fixture):
     fixture = load_transaction_fixture('transfer')
@@ -26,4 +27,22 @@ def test_it_should_sign_it_with_a_passphrase(passphrase, load_transaction_fixtur
 
     assert builder.transaction.serialize().hex() == fixture['serialized']
     assert builder.transaction.data['id'] == fixture['data']['id']
+    assert builder.verify()
+
+def test_it_should_handle_unit_converter(passphrase, address):
+    builder = (
+        TransferBuilder()
+            .gas_price(UnitConverter.parse_units(5, 'gwei'))
+            .nonce('1')
+            .gas_limit(UnitConverter.parse_units(0.1, 'gwei'))
+            .recipient_address(address)
+            .value(UnitConverter.parse_units(10, 'ark'))
+            .sign(passphrase)
+    )
+
+    assert builder.transaction.data['gasPrice'] == '5000000000'
+    assert builder.transaction.data['nonce'] == '1'
+    assert builder.transaction.data['gasLimit'] == '100000000'
+    assert builder.transaction.data['value'] == '10000000000000000000'
+
     assert builder.verify()

--- a/tests/transactions/builder/test_unvote_builder.py
+++ b/tests/transactions/builder/test_unvote_builder.py
@@ -18,7 +18,7 @@ def test_unvote_transaction(passphrase, load_transaction_fixture):
     assert builder.transaction.data['network'] == fixture['data']['network']
     assert builder.transaction.data['gasLimit'] == fixture['data']['gasLimit']
     assert builder.transaction.data['recipientAddress'] == fixture['data']['recipientAddress']
-    assert builder.transaction.data['value'] == fixture['data']['value']
+    assert builder.transaction.data['value'] == int(fixture['data']['value'])
     assert builder.transaction.data['v'] == fixture['data']['v']
     assert builder.transaction.data['r'] == fixture['data']['r']
     assert builder.transaction.data['s'] == fixture['data']['s']
@@ -44,7 +44,7 @@ def test_unvote_transaction_with_default_recipient_address(passphrase, load_tran
     assert builder.transaction.data['network'] == fixture['data']['network']
     assert builder.transaction.data['gasLimit'] == fixture['data']['gasLimit']
     assert builder.transaction.data['recipientAddress'].lower() == fixture['data']['recipientAddress'].lower()
-    assert builder.transaction.data['value'] == fixture['data']['value']
+    assert builder.transaction.data['value'] == int(fixture['data']['value'])
     assert builder.transaction.data['v'] == fixture['data']['v']
     assert builder.transaction.data['r'] == fixture['data']['r']
     assert builder.transaction.data['s'] == fixture['data']['s']

--- a/tests/transactions/builder/test_validator_registration_builder.py
+++ b/tests/transactions/builder/test_validator_registration_builder.py
@@ -20,7 +20,7 @@ def test_validator_registration_transaction(passphrase, validator_public_key, lo
     assert builder.transaction.data['network'] == fixture['data']['network']
     assert builder.transaction.data['gasLimit'] == fixture['data']['gasLimit']
     assert builder.transaction.data['recipientAddress'] == fixture['data']['recipientAddress']
-    assert builder.transaction.data['value'] == fixture['data']['value']
+    assert builder.transaction.data['value'] == int(fixture['data']['value'])
     assert builder.transaction.data['v'] == fixture['data']['v']
     assert builder.transaction.data['r'] == fixture['data']['r']
     assert builder.transaction.data['s'] == fixture['data']['s']
@@ -47,7 +47,7 @@ def test_validator_registration_transaction_with_default_recipient_address(passp
     assert builder.transaction.data['network'] == fixture['data']['network']
     assert builder.transaction.data['gasLimit'] == fixture['data']['gasLimit']
     assert builder.transaction.data['recipientAddress'].lower() == fixture['data']['recipientAddress'].lower()
-    assert builder.transaction.data['value'] == fixture['data']['value']
+    assert builder.transaction.data['value'] == int(fixture['data']['value'])
     assert builder.transaction.data['v'] == fixture['data']['v']
     assert builder.transaction.data['r'] == fixture['data']['r']
     assert builder.transaction.data['s'] == fixture['data']['s']

--- a/tests/transactions/builder/test_validator_resignation_builder.py
+++ b/tests/transactions/builder/test_validator_resignation_builder.py
@@ -18,7 +18,7 @@ def test_validator_resignation_transaction(passphrase, load_transaction_fixture)
     assert builder.transaction.data['network'] == fixture['data']['network']
     assert builder.transaction.data['gasLimit'] == fixture['data']['gasLimit']
     assert builder.transaction.data['recipientAddress'] == fixture['data']['recipientAddress']
-    assert builder.transaction.data['value'] == fixture['data']['value']
+    assert builder.transaction.data['value'] == int(fixture['data']['value'])
     assert builder.transaction.data['v'] == fixture['data']['v']
     assert builder.transaction.data['r'] == fixture['data']['r']
     assert builder.transaction.data['s'] == fixture['data']['s']
@@ -44,7 +44,7 @@ def test_validator_resignation_transaction_with_default_recipient_address(passph
     assert builder.transaction.data['network'] == fixture['data']['network']
     assert builder.transaction.data['gasLimit'] == fixture['data']['gasLimit']
     assert builder.transaction.data['recipientAddress'].lower() == fixture['data']['recipientAddress'].lower()
-    assert builder.transaction.data['value'] == fixture['data']['value']
+    assert builder.transaction.data['value'] == int(fixture['data']['value'])
     assert builder.transaction.data['v'] == fixture['data']['v']
     assert builder.transaction.data['r'] == fixture['data']['r']
     assert builder.transaction.data['s'] == fixture['data']['s']

--- a/tests/transactions/builder/test_vote_builder.py
+++ b/tests/transactions/builder/test_vote_builder.py
@@ -19,7 +19,7 @@ def test_vote_transaction(passphrase, load_transaction_fixture):
     assert builder.transaction.data['network'] == fixture['data']['network']
     assert builder.transaction.data['gasLimit'] == fixture['data']['gasLimit']
     assert builder.transaction.data['recipientAddress'] == fixture['data']['recipientAddress']
-    assert builder.transaction.data['value'] == fixture['data']['value']
+    assert builder.transaction.data['value'] == int(fixture['data']['value'])
     assert builder.transaction.data['v'] == fixture['data']['v']
     assert builder.transaction.data['r'] == fixture['data']['r']
     assert builder.transaction.data['s'] == fixture['data']['s']
@@ -46,7 +46,7 @@ def test_vote_transaction_with_default_recipient_address(passphrase, load_transa
     assert builder.transaction.data['network'] == fixture['data']['network']
     assert builder.transaction.data['gasLimit'] == fixture['data']['gasLimit']
     assert builder.transaction.data['recipientAddress'].lower() == fixture['data']['recipientAddress'].lower()
-    assert builder.transaction.data['value'] == fixture['data']['value']
+    assert builder.transaction.data['value'] == int(fixture['data']['value'])
     assert builder.transaction.data['v'] == fixture['data']['v']
     assert builder.transaction.data['r'] == fixture['data']['r']
     assert builder.transaction.data['s'] == fixture['data']['s']

--- a/tests/transactions/test_serializer.py
+++ b/tests/transactions/test_serializer.py
@@ -14,7 +14,6 @@ def test_transfer_serialization(load_transaction_fixture):
 def test_vote_serialization(load_transaction_fixture):
     fixture = load_transaction_fixture('vote')
     transaction = Vote(fixture['data'])
-    print(f"transaction: {transaction.data}")
     serializer = Serializer.new(transaction)
     assert serializer.serialize().hex() == fixture['serialized']
 

--- a/tests/utils/test_unit_converter.py
+++ b/tests/utils/test_unit_converter.py
@@ -2,41 +2,41 @@ from crypto.utils.unit_converter import UnitConverter
 from decimal import Decimal
 
 def test_it_should_parse_units_into_wei():
-    assert UnitConverter.parse_units(1, 'wei') == '1'
-    assert UnitConverter.parse_units(1.0, 'wei') == '1'
-    assert UnitConverter.parse_units('1', 'wei') == '1'
-    assert UnitConverter.parse_units('1.0', 'wei') == '1'
+    assert UnitConverter.parse_units(1, 'wei') == 1
+    assert UnitConverter.parse_units(1.0, 'wei') == 1
+    assert UnitConverter.parse_units('1', 'wei') == 1
+    assert UnitConverter.parse_units('1.0', 'wei') == 1
 
-    assert UnitConverter.parse_units(Decimal(1), 'wei') == '1'
-    assert UnitConverter.parse_units(Decimal(1.0), 'wei') == '1'
-    assert UnitConverter.parse_units(Decimal('1'), 'wei') == '1'
-    assert UnitConverter.parse_units(Decimal('1.0'), 'wei') == '1'
+    assert UnitConverter.parse_units(Decimal(1), 'wei') == 1
+    assert UnitConverter.parse_units(Decimal(1.0), 'wei') == 1
+    assert UnitConverter.parse_units(Decimal('1'), 'wei') == 1
+    assert UnitConverter.parse_units(Decimal('1.0'), 'wei') == 1
 
 def test_it_should_parse_units_into_gwei():
-    assert UnitConverter.parse_units(1, 'gwei') == '1000000000'
-    assert UnitConverter.parse_units(1.0, 'gwei') == '1000000000'
-    assert UnitConverter.parse_units('1', 'gwei') == '1000000000'
-    assert UnitConverter.parse_units('1.0', 'gwei') == '1000000000'
+    assert UnitConverter.parse_units(1, 'gwei') == 1000000000
+    assert UnitConverter.parse_units(1.0, 'gwei') == 1000000000
+    assert UnitConverter.parse_units('1', 'gwei') == 1000000000
+    assert UnitConverter.parse_units('1.0', 'gwei') == 1000000000
 
-    assert UnitConverter.parse_units(Decimal(1), 'gwei') == '1000000000'
-    assert UnitConverter.parse_units(Decimal(1.0), 'gwei') == '1000000000'
-    assert UnitConverter.parse_units(Decimal('1'), 'gwei') == '1000000000'
-    assert UnitConverter.parse_units(Decimal('1.0'), 'gwei') == '1000000000'
+    assert UnitConverter.parse_units(Decimal(1), 'gwei') == 1000000000
+    assert UnitConverter.parse_units(Decimal(1.0), 'gwei') == 1000000000
+    assert UnitConverter.parse_units(Decimal('1'), 'gwei') == 1000000000
+    assert UnitConverter.parse_units(Decimal('1.0'), 'gwei') == 1000000000
 
 def test_it_should_parse_units_into_ark():
-    assert UnitConverter.parse_units(1, 'ark') == '1000000000000000000'
-    assert UnitConverter.parse_units(1.0, 'ark') == '1000000000000000000'
-    assert UnitConverter.parse_units('1', 'ark') == '1000000000000000000'
-    assert UnitConverter.parse_units('1.0', 'ark') == '1000000000000000000'
+    assert UnitConverter.parse_units(1, 'ark') == 1000000000000000000
+    assert UnitConverter.parse_units(1.0, 'ark') == 1000000000000000000
+    assert UnitConverter.parse_units('1', 'ark') == 1000000000000000000
+    assert UnitConverter.parse_units('1.0', 'ark') == 1000000000000000000
 
-    assert UnitConverter.parse_units(Decimal(1), 'ark') == '1000000000000000000'
-    assert UnitConverter.parse_units(Decimal(1.0), 'ark') == '1000000000000000000'
-    assert UnitConverter.parse_units(Decimal('1'), 'ark') == '1000000000000000000'
-    assert UnitConverter.parse_units(Decimal('1.0'), 'ark') == '1000000000000000000'
+    assert UnitConverter.parse_units(Decimal(1), 'ark') == 1000000000000000000
+    assert UnitConverter.parse_units(Decimal(1.0), 'ark') == 1000000000000000000
+    assert UnitConverter.parse_units(Decimal('1'), 'ark') == 1000000000000000000
+    assert UnitConverter.parse_units(Decimal('1.0'), 'ark') == 1000000000000000000
 
 def test_it_should_parse_decimal_units_into_ark():
-    assert UnitConverter.parse_units(0.1, 'ark') == '100000000000000000'
-    assert UnitConverter.parse_units('0.1', 'ark') == '100000000000000000'
+    assert UnitConverter.parse_units(0.1, 'ark') == 100000000000000000
+    assert UnitConverter.parse_units('0.1', 'ark') == 100000000000000000
 
 def test_it_should_format_units_from_wei():
     assert UnitConverter.format_units(1, 'wei') == 1.0
@@ -76,8 +76,8 @@ def test_it_should_throw_exception_for_unsupported_unit_in_format():
         assert str(e) == 'Unsupported unit: unsupported. Supported units are \'wei\', \'gwei\', and \'ark\'.'
 
 def test_it_should_parse_units_into_ark_with_fraction():
-    assert UnitConverter.parse_units(0.1, 'ark') == '100000000000000000'
-    assert UnitConverter.parse_units('0.1', 'ark') == '100000000000000000'
+    assert UnitConverter.parse_units(0.1, 'ark') == 100000000000000000
+    assert UnitConverter.parse_units('0.1', 'ark') == 100000000000000000
 
 def test_it_should_convert_wei_to_ark():
     assert UnitConverter.wei_to_ark(1, 'DARK') == '0.000000000000000001 DARK'


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dw15f4f

Originally this PR was to handle strings as a type for passing values in to the `value`, `gas_price` and `gas_limit` methods. Now UnitConverter has been updated to match the new PHP Crypto SDK where the UnitConverter#parse_units method returns an int which can be passed straight into one of the above methods.

todo:

- [ ] docs

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
