### PR TITLE
refactor: make transaction methods protected

### DIFF
--- a/crypto/transactions/types/abstract_transaction.py
+++ b/crypto/transactions/types/abstract_transaction.py
@@ -41,7 +41,7 @@ class AbstractTransaction:
         return public_key
 
     def recover_sender(self):
-        signature_with_recid = self.get_signature()
+        signature_with_recid = self._get_signature()
         if not signature_with_recid:
             return False
 
@@ -51,7 +51,7 @@ class AbstractTransaction:
         self.data['senderAddress'] = Address.from_public_key(self.data['senderPublicKey'])
 
     def verify(self) -> bool:
-        signature_with_recid = self.get_signature()
+        signature_with_recid = self._get_signature()
         if not signature_with_recid:
             return False
 
@@ -79,7 +79,7 @@ class AbstractTransaction:
     def hash(self, skip_signature: bool) -> str:
         return TransactionUtils.to_hash(self.data, skip_signature=skip_signature)
 
-    def get_signature(self):
+    def _get_signature(self):
         recover_id = int(self.data.get('v', 0)) - Constants.ETHEREUM_RECOVERY_ID_OFFSET.value
         r = self.data.get('r')
         s = self.data.get('s')

--- a/crypto/transactions/types/abstract_transaction.py
+++ b/crypto/transactions/types/abstract_transaction.py
@@ -90,7 +90,7 @@ class AbstractTransaction:
         return None
 
     @staticmethod
-    def decode_payload(data: dict, abi_type: ContractAbiType = ContractAbiType.CONSENSUS) -> Optional[dict]:
+    def _decode_payload(data: dict, abi_type: ContractAbiType = ContractAbiType.CONSENSUS) -> Optional[dict]:
         from crypto.transactions.deserializer import Deserializer
 
         return Deserializer.decode_payload(data, abi_type)

--- a/crypto/transactions/types/multipayment.py
+++ b/crypto/transactions/types/multipayment.py
@@ -6,7 +6,7 @@ from crypto.enums.abi_function import AbiFunction
 
 class Multipayment(AbstractTransaction):
     def __init__(self, data: dict):
-        payload = self.decode_payload(data, ContractAbiType.MULTIPAYMENT)
+        payload = self._decode_payload(data, ContractAbiType.MULTIPAYMENT)
         if payload:
             data['pay'] = payload.get('args', [])
 

--- a/crypto/transactions/types/username_registration.py
+++ b/crypto/transactions/types/username_registration.py
@@ -6,7 +6,7 @@ from crypto.enums.abi_function import AbiFunction
 
 class UsernameRegistration(AbstractTransaction):
     def __init__(self, data: dict):
-        payload = self.decode_payload(data, ContractAbiType.USERNAMES)
+        payload = self._decode_payload(data, ContractAbiType.USERNAMES)
         if payload:
             data['username'] = payload.get('args', [None])[0] if payload.get('args') else None
 

--- a/crypto/transactions/types/validator_registration.py
+++ b/crypto/transactions/types/validator_registration.py
@@ -6,9 +6,10 @@ from crypto.utils.transaction_utils import TransactionUtils
 
 class ValidatorRegistration(AbstractTransaction):
     def __init__(self, data: dict):
-        payload = self.decode_payload(data)
+        payload = self._decode_payload(data)
         if payload:
             data['validatorPublicKey'] = TransactionUtils.parse_hex_from_str(payload.get('args', [None])[0]) if payload.get('args') else None
+
         super().__init__(data)
 
     def get_payload(self) -> str:

--- a/crypto/transactions/types/vote.py
+++ b/crypto/transactions/types/vote.py
@@ -5,7 +5,7 @@ from crypto.enums.abi_function import AbiFunction
 
 class Vote(AbstractTransaction):
     def __init__(self, data: dict):
-        payload = self.decode_payload(data)
+        payload = self._decode_payload(data)
         if payload:
             data['vote'] = payload.get('args', [None])[0] if payload.get('args') else None
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Noticed while working on https://app.clickup.com/t/86dwdpbfv

Python doesn't support "protected" methods, so I've used a `_` to highlight it's not to be used

Methods updated:

- `decode_payload`
- `get_signature`

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
